### PR TITLE
Make file-writing optional

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ module.exports = {
   name: 'Dev',
 
   init: (config = {}, settings = {}) => {
-    const publicDir = strapi.dirs.public
+    const publicDir = path.resolve(strapi.dir, 'public')
     const { dir = publicDir } = config
 
     return {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,33 +10,35 @@ module.exports = {
   provider: 'dev',
   name: 'Dev',
 
-  init: (config = {}, settings = {}) => {  
-    const publicDir = path.resolve(strapi.dir, 'public')
+  init: (config = {}, settings = {}) => {
+    const publicDir = strapi.dirs.public
     const { dir = publicDir } = config
 
     return {
       send: async options => {
-        const { 
-          from, 
-          to, 
-          subject, 
-          text, 
-          html, 
+        const {
+          from,
+          to,
+          subject,
+          text,
+          html,
         } = options
 
         strapi.log.info(`Email to <${options.to}>: "${options.subject}"`)
 
-        if (options.text) {
-          const filename = path.join(dir, 'email.txt')
-          await fs.writeFile(filename, options.text, 'utf8')
-          strapi.log.info(`- wrote: ${filename}`)
-        }
+        // TODO: make this a config flag.
+        if (process.env.DEV_EMAIL_WRITE_FILE) {
+          if (options.text) {
+            const filename = path.join(dir, 'email.txt')
+            await fs.writeFile(filename, options.text, 'utf8')
+            strapi.log.info(`- wrote: ${filename}`)
+          }
           
-        if (options.html) {
-          const filename = path.join(dir, 'email.html')
-          await fs.writeFile(filename, options.html, 'utf8')
-          
-          strapi.log.info(`- wrote: ${filename}`)
+          if (options.html) {
+            const filename = path.join(dir, 'email.html')
+            await fs.writeFile(filename, options.html, 'utf8')
+            strapi.log.info(`- wrote: ${filename}`)
+          }
         }
       },
     };

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   "license": "MIT",
   "dependencies": {
     "fs-extra": "^10.0.0"
+  },
+  "strapi": {
+    "isProvider": true
   }
 }


### PR DESCRIPTION
Emails will only be written to file if the `DEV_EMAIL_WRITE_FILE` environment variable is set.

In hosted non-production environments with a lot of email processing, enabling file-writing may cause the server to lock.